### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You may want to implement your own custom logic by adding 'state_machine' hooks.
 
 Add to your Spree application Gemfile.
 
-    gem "pp_website_standard", :git => "git://github.com/tomash/spree-pp-website-standard.git"
+    gem "spree_paypal_website_standard", :git => "git://github.com/tomash/spree-pp-website-standard.git"
 
 Run the install rake task to copiy migrations (create payment_notifications table)
 


### PR DESCRIPTION
I just updated the installation instructions. The current one won't work with current gemspec.
