### PR TITLE
added method to check for all elements required to encrypt paypal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The last three are required for secure, encrypted operation (see below).
 
 ## Encryption / Security
 
+The payment link can be encrypted using an SSL key pair and a PayPal public key. In order to attempt this encryption, the following elements must be available. If these are not available a normal link will be generated.
+
 Spree::Paypal::Config[:encrypted] must be set to true.
 Spree::Paypal::Config[:cert_id] must be set to a valid certificate id.
 Spree::Paypal::Config[:ipn_secret] must be set to a string considered secret.

--- a/app/models/order_decorator.rb
+++ b/app/models/order_decorator.rb
@@ -1,6 +1,11 @@
 Order.class_eval do
   has_many :payment_notifications
   
+  # SSL certificates for encrypting paypal link
+  PAYPAL_CERT_PEM = "#{Rails.root}/certs/paypal_cert_#{Rails.env}.pem"  
+  APP_CERT_PEM = "#{Rails.root}/certs/app_cert.pem"  
+  APP_KEY_PEM = "#{Rails.root}/certs/app_key.pem"  
+ 
   def shipment_cost
     adjustment_total - credit_total
   end
@@ -11,6 +16,15 @@ Order.class_eval do
 
   def self.paypal_payment_method
     PaymentMethod.select{ |pm| pm.name.downcase =~ /paypal/}.first
+  end
+
+  def self.use_encrypted_paypal_link?
+    Spree::Paypal::Config[:encryption] &&
+    Spree::Paypal::Config[:ipn_secret] &&
+    Spree::Paypal::Config[:cert_id] &&
+    File.exist?(PAYPAL_CERT_PEM) &&   
+    File.exist?(APP_CERT_PEM) &&   
+    File.exist?(APP_KEY_PEM)   
   end
   
   def paypal_encrypted(payment_notifications_url, options = {})
@@ -39,11 +53,12 @@ Order.class_eval do
     encrypt_for_paypal(values)  
   end
   
-  PAYPAL_CERT_PEM = File.read("#{Rails.root}/certs/paypal_cert_#{Rails.env}.pem")  
-  APP_CERT_PEM = File.read("#{Rails.root}/certs/app_cert.pem")  
-  APP_KEY_PEM = File.read("#{Rails.root}/certs/app_key.pem")  
   def encrypt_for_paypal(values)  
-    signed = OpenSSL::PKCS7::sign(OpenSSL::X509::Certificate.new(APP_CERT_PEM), OpenSSL::PKey::RSA.new(APP_KEY_PEM, ''), values.map { |k, v| "#{k}=#{v}" }.join("\n"), [], OpenSSL::PKCS7::BINARY)  
-    OpenSSL::PKCS7::encrypt([OpenSSL::X509::Certificate.new(PAYPAL_CERT_PEM)], signed.to_der, OpenSSL::Cipher::Cipher::new("DES3"), OpenSSL::PKCS7::BINARY).to_s.gsub("\n", "")  
+    paypal_cert = File.read(PAYPAL_CERT_PEM)
+    app_cert = File.read(APP_CERT_PEM)
+    app_key = File.read(APP_KEY_PEM)
+    signed = OpenSSL::PKCS7::sign(OpenSSL::X509::Certificate.new(app_cert), OpenSSL::PKey::RSA.new(app_key, ''), values.map { |k, v| "#{k}=#{v}" }.join("\n"), [], OpenSSL::PKCS7::BINARY)  
+    OpenSSL::PKCS7::encrypt([OpenSSL::X509::Certificate.new(paypal_cert)], signed.to_der, OpenSSL::Cipher::Cipher::new("DES3"), OpenSSL::PKCS7::BINARY).to_s.gsub("\n", "")  
   end
+
 end

--- a/app/views/checkout/_paypal_checkout.html.erb
+++ b/app/views/checkout/_paypal_checkout.html.erb
@@ -6,7 +6,7 @@
 %>
 <%= form_tag submit_url do %> 
 
-  <%- if(Spree::Paypal::Config[:encryption]) %>
+  <%- if(Order.use_encrypted_paypal_link?) %>
     <%= hidden_field_tag(:cmd, "_s-xclick") %>
     <%= hidden_field_tag(:encrypted, @order.paypal_encrypted(payment_notifications_url(:secret => Spree::Paypal::Config[:ipn_secret]))) %>
   <% else %>


### PR DESCRIPTION
My bundle install was breaking when there is no /certs directory or the pem files were missing. I've added a method to check if all the certificates and configs are available before invoking the link encryption method.
