### PR TITLE
Add page_style and tax_cart.

### DIFF
--- a/app/models/order_decorator.rb
+++ b/app/models/order_decorator.rb
@@ -39,7 +39,8 @@ Order.class_eval do
       :notify_url => payment_notifications_url,
       :charset => "utf-8",
       :cert_id => Spree::Paypal::Config[:cert_id],
-      :page_style => Spree::Paypal::Config[:page_style]
+      :page_style => Spree::Paypal::Config[:page_style],
+      :tax_cart => self.tax_total
     }  
       
     self.line_items.each_with_index do |item, index|  

--- a/app/models/order_decorator.rb
+++ b/app/models/order_decorator.rb
@@ -38,7 +38,8 @@ Order.class_eval do
       :return => Spree::Paypal::Config[:success_url],
       :notify_url => payment_notifications_url,
       :charset => "utf-8",
-      :cert_id => Spree::Paypal::Config[:cert_id]
+      :cert_id => Spree::Paypal::Config[:cert_id],
+      :page_style => Spree::Paypal::Config[:page_style]
     }  
       
     self.line_items.each_with_index do |item, index|  

--- a/app/views/checkout/_paypal_checkout.html.erb
+++ b/app/views/checkout/_paypal_checkout.html.erb
@@ -11,6 +11,7 @@
     <%= hidden_field_tag(:encrypted, @order.paypal_encrypted(payment_notifications_url(:secret => Spree::Paypal::Config[:ipn_secret]))) %>
   <% else %>
   
+    <input id="page_style" name="page_style" type="hidden" value="<%= Spree::Paypal::Config[:page_style] %>"/>
     <input id="business" name="business" type="hidden" value="<%= Spree::Paypal::Config[:account] %>" />
     <input id="invoice" name="invoice" type="hidden" value="<%= @order.number %>" />
     

--- a/lib/paypal_configuration.rb
+++ b/lib/paypal_configuration.rb
@@ -10,12 +10,13 @@ class PaypalConfiguration < Configuration
   
   # this stuff is really handy
   preference :currency_code, :string, :default => "EUR"
+  preference :page_style, :string, :default => 'PayPal'
   
   # encryption / security
   preference :encrypted, :boolean, :default => false
   preference :cert_id, :string, :default => "12345678"
   preference :ipn_secret, :string, :default => "secret"
-  
+
   validates_presence_of :name
   validates_uniqueness_of :name
 end


### PR DESCRIPTION
If you have a bunch of sites using the same paypal business account then you want to be able to set the page style so that customers have the right checkout experience.
Also, tax_cart was not being added to encrypted paypal submissions, which is fixed now.
