### PR TITLE
Handle IPN encoding (ArgumentError (invalid byte sequence in UTF-8))

### DIFF
--- a/app/controllers/payment_notifications_controller.rb
+++ b/app/controllers/payment_notifications_controller.rb
@@ -86,7 +86,7 @@ class PaymentNotificationsController < ApplicationController
 
   # Reencode all strings when PayPal encoding differs from our Ruby string encoding
   def encode_params
-    if params[:charset] and Encoding.find(params[:charset]) != Enconding.default_internal
+    if params[:charset] and Encoding.find(params[:charset]) != Encoding.default_internal
       params.each_pair do |key, value|
         params[key] = value.force_encoding(params[:charset]).encode! Encoding.default_internal
       end

--- a/app/controllers/payment_notifications_controller.rb
+++ b/app/controllers/payment_notifications_controller.rb
@@ -87,8 +87,8 @@ class PaymentNotificationsController < ApplicationController
   # Reencode all strings when PayPal encoding differs from our Ruby string encoding
   def encode_params
     if params[:charset] and "".force_enconding(params[:charset]).encoding != Enconding.default_internal
-      params.each_value do |value|
-        value.force_encoding(params[:charset]).encode! Encoding.default_internal
+      params.each_pair do |key, value|
+        params[key] = value.force_encoding(params[:charset]).encode! Encoding.default_internal
       end
     end
   end

--- a/app/controllers/payment_notifications_controller.rb
+++ b/app/controllers/payment_notifications_controller.rb
@@ -86,6 +86,7 @@ class PaymentNotificationsController < ApplicationController
 
   # Reencode all strings when PayPal encoding differs from our Ruby string encoding
   def encode_params
+    return unless Spree::Paypal::Config[:force_internal_encoding]
     if params[:charset] and Encoding.find(params[:charset]) != Encoding.default_internal
       params.each_pair do |key, value|
         params[key] = value.force_encoding(params[:charset]).encode! Encoding.default_internal

--- a/app/controllers/payment_notifications_controller.rb
+++ b/app/controllers/payment_notifications_controller.rb
@@ -1,6 +1,7 @@
 class PaymentNotificationsController < ApplicationController
   protect_from_forgery :except => [:create]
   skip_before_filter :restriction_access  
+  before_filter :encode_params, :only => :create
   
   def create
     if(Spree::Paypal::Config[:encryption] && (params[:secret] != Spree::Paypal::Config[:ipn_secret]))
@@ -81,6 +82,15 @@ class PaymentNotificationsController < ApplicationController
 
   def default_country
     Country.find Spree::Config[:default_country_id]
+  end
+
+  # Reencode all strings when PayPal encoding differs from our Ruby string encoding
+  def encode_params
+    if params[:charset] and "".force_enconding(params[:charset]).encoding != Enconding.default_internal
+      params.each_value do |value|
+        value.force_encoding(params[:charset]).encode! Encoding.default_internal
+      end
+    end
   end
 
 end

--- a/app/controllers/payment_notifications_controller.rb
+++ b/app/controllers/payment_notifications_controller.rb
@@ -86,7 +86,7 @@ class PaymentNotificationsController < ApplicationController
 
   # Reencode all strings when PayPal encoding differs from our Ruby string encoding
   def encode_params
-    if params[:charset] and "".force_enconding(params[:charset]).encoding != Enconding.default_internal
+    if params[:charset] and Encoding.find(params[:charset]) != Enconding.default_internal
       params.each_pair do |key, value|
         params[key] = value.force_encoding(params[:charset]).encode! Encoding.default_internal
       end

--- a/lib/paypal_configuration.rb
+++ b/lib/paypal_configuration.rb
@@ -17,6 +17,9 @@ class PaypalConfiguration < Configuration
   preference :cert_id, :string, :default => "12345678"
   preference :ipn_secret, :string, :default => "secret"
 
+  # encoding
+  preference :force_encoding, :boolean, :default => false
+
   validates_presence_of :name
   validates_uniqueness_of :name
 end


### PR DESCRIPTION
I was having trouble when receiving IPN messages from the PayPal sandbox. Since I am form Spain, some strings that came from the IPN parameters had special characters, like tilde. PayPal is sending the data encoded in windows-1252 and by default ruby expects utf-8 strings.
Luckly one of the IPN parameters received is the encoding PayPal has used, so I just added a before_filter to reencode these parameters in case our encoding is different.
Above I post an example of the error. To reproduce try to save a new PaymentNotification with this has on the params attribute. Things like "address_name"=>"Pepe Garc\xEDa" make it fail.

``` ruby
Started POST "/payment_notifications?secret=1234" for 173.0.82.126 at 2012-02-27 18:11:45 +0100
  Processing by PaymentNotificationsController#create as HTML
  Parameters: {"mc_gross"=>"22.92", "invoice"=>"R143801041", "protection_eligibility"=>"Ineligible", "address_status"=>"unconfirmed", "item_number1"=>"[FILTERED]", "payer_id"=>"G2K26WSJJ5ZGC", "tax"=>"0.00", "address_street"=>"calle Vilamar 76993- 17469", "payment_date"=>"08:50:12 Feb 27, 2012 PST", "payment_status"=>"Completed", "charset"=>"windows-1252", "address_zip"=>"02001", "mc_shipping"=>"0.00", "mc_handling"=>"0.00", "first_name"=>"Pepe", "mc_fee"=>"1.13", "address_country_code"=>"ES", "address_name"=>"Pepe Garc\xEDa", "notify_version"=>"3.4", "custom"=>"", "payer_status"=>"verified", "business"=>"venta_1330311618_biz@camuber.es", "address_country"=>"Spain", "num_cart_items"=>"1", "mc_handling1"=>"0.00", "address_city"=>"Albacete", "verify_sign"=>"Aaekt-ook78znSghzEZW5FreMIK7ADyH7zElHAX8rt7KYIgxWJvfZ27K", "payer_email"=>"compra_1330311564_per@camuber.es", "mc_shipping1"=>"0.00", "txn_id"=>"3HS13290BJ013401P", "payment_type"=>"instant", "last_name"=>"Garc\xEDa", "address_state"=>"Albacete", "item_name1"=>"Horca de acero forjado de 4 p\xFAas con mango.", "receiver_email"=>"venta_1330311618_biz@camuber.es", "payment_fee"=>"", "quantity1"=>"1", "receiver_id"=>"35BX5YMNYMW6G", "txn_type"=>"cart", "mc_gross_1"=>"22.92", "mc_currency"=>"EUR", "residence_country"=>"ES", "test_ipn"=>"1", "transaction_subject"=>"Shopping CartHorca de acero forjado de 4 p\xFAas con mango.", "payment_gross"=>"", "ipn_track_id"=>"7ff71ef78d547", "secret"=>"1234"}
Completed 500 Internal Server Error in 24ms

ArgumentError (invalid byte sequence in UTF-8):
```
